### PR TITLE
Remove timetable link and note

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,10 +116,6 @@
             <div class="row"><div class="k">場所</div><div class="v">座光寺小学校 グラウンド（雨天: 体育館）</div></div>
             <div class="row"><div class="k">持ち物</div><div class="v">タオル、帽子、運動のできる服装（スパイクは禁止）</div></div>
           </div>
-          <div class="flex" style="margin-top:16px">
-            <a href="#schedule" class="btn secondary">📅 タイムテーブル</a>
-          </div>
-          <p class="note" style="margin-top:10px">※ 受付・進行は状況により前後する場合があります。</p>
         </div>
         <aside class="card" aria-label="お知らせ">
           <h3>最新のお知らせ</h3>


### PR DESCRIPTION
## Summary
- remove timetable button and caution note from the event card

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac0d7bf48326b6a23f1274f6efc8