### PR TITLE
Remove 9/15 announcement from latest news

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,6 @@
         <aside class="card" aria-label="お知らせ">
           <h3>最新のお知らせ</h3>
           <ul class="list">
-            <li>9/15: 種目の最終調整を行いました。雨天時は体育館で実施します。</li>
             <li>9/01: 告知ページを公開しました。</li>
           </ul>
           <div class="chips" style="margin-top:12px">


### PR DESCRIPTION
## Summary
- remove outdated 9/15 announcement from "最新のお知らせ" list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ad33ab1c8326b9b6e9388ba6615e