### PR TITLE
feat: move start time to first column

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,20 +134,20 @@
     <section id="schedule" class="card">
       <h2>タイムテーブル</h2>
       <table class="table" aria-describedby="schedule-note">
-        <thead><tr><th>種目</th><th>出場者</th><th>スタート時間</th><th>競技時間</th></tr></thead>
+        <thead><tr><th>スタート時間</th><th>種目</th><th>出場者</th><th>競技時間</th></tr></thead>
         <tbody>
-          <tr><td>開会式</td><td>全員</td><td>8:30</td><td>15</td></tr>
-          <tr><td>準備運動</td><td>全員</td><td>8:45</td><td>10</td></tr>
-          <tr><td>アスレチック競争</td><td>小学生</td><td>8:55</td><td>15</td></tr>
-          <tr><td>責任重大</td><td>各地区選手</td><td>9:10</td><td>20</td></tr>
-          <tr><td>ラッキーデカパン</td><td>各地区選手</td><td>9:30</td><td>20</td></tr>
-          <tr><td>団体PRタイム</td><td>-</td><td>9:50</td><td>5</td></tr>
-          <tr><td>中学生企画</td><td>オープン参加</td><td>9:55</td><td>25</td></tr>
-          <tr><td>早くいっぱい入れて</td><td>各地区選手</td><td>10:20</td><td>20</td></tr>
-          <tr><td>ジャンボバトンリレー</td><td>各地区選手</td><td>10:40</td><td>25</td></tr>
-          <tr><td>メドレーリレー</td><td>各地区選手</td><td>11:05</td><td>25</td></tr>
-          <tr><td>立つ鳥あとをにごさず</td><td>全員</td><td>11:30</td><td>5</td></tr>
-          <tr><td>閉会式</td><td>全員</td><td>11:35</td><td>15</td></tr>
+          <tr><td>8:30</td><td>開会式</td><td>全員</td><td>15</td></tr>
+          <tr><td>8:45</td><td>準備運動</td><td>全員</td><td>10</td></tr>
+          <tr><td>8:55</td><td>アスレチック競争</td><td>小学生</td><td>15</td></tr>
+          <tr><td>9:10</td><td>責任重大</td><td>各地区選手</td><td>20</td></tr>
+          <tr><td>9:30</td><td>ラッキーデカパン</td><td>各地区選手</td><td>20</td></tr>
+          <tr><td>9:50</td><td>団体PRタイム</td><td>-</td><td>5</td></tr>
+          <tr><td>9:55</td><td>中学生企画</td><td>オープン参加</td><td>25</td></tr>
+          <tr><td>10:20</td><td>早くいっぱい入れて</td><td>各地区選手</td><td>20</td></tr>
+          <tr><td>10:40</td><td>ジャンボバトンリレー</td><td>各地区選手</td><td>25</td></tr>
+          <tr><td>11:05</td><td>メドレーリレー</td><td>各地区選手</td><td>25</td></tr>
+          <tr><td>11:30</td><td>立つ鳥あとをにごさず</td><td>全員</td><td>5</td></tr>
+          <tr><td>11:35</td><td>閉会式</td><td>全員</td><td>15</td></tr>
         </tbody>
       </table>
       <p id="schedule-note" class="note">* 進行状況により変更となる場合があります。</p>


### PR DESCRIPTION
## Summary
- move start time to the first column in the timetable

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1cbd9a08326a1d246ab809b040b