### PR TITLE
Remove outdated sports

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,24 +150,6 @@
 
     <section id="sports" class="card">
       <h2>主な競技</h2>
-        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap:16px">
-          <div class="card" style="background:rgba(34,211,238,.06)">
-            <h3>囲碁ボール</h3>
-            <p class="muted">年齢問わず楽しめる命中系ゲーム。ルール説明あり。</p>
-          </div>
-          <div class="card" style="background:rgba(56,189,248,.06)">
-            <h3>スローインボトル</h3>
-            <p class="muted">狙って倒して盛り上がる！初めてでもOK。</p>
-          </div>
-          <div class="card" style="background:rgba(34,197,94,.08)">
-            <h3>ペタンク</h3>
-            <p class="muted">フランス発祥の球技。屋外での実施を予定。</p>
-          </div>
-          <div class="card" style="background:rgba(245,158,11,.08)">
-            <h3>モルック</h3>
-            <p class="muted">フィンランド生まれの木のピン倒しゲーム。</p>
-          </div>
-        </div>
         <div class="center" style="margin-top:16px">
           <a href="src/rulebook.pdf" class="btn secondary" target="_blank" rel="noopener">競技ルールブック（PDF）</a>
         </div>


### PR DESCRIPTION
## Summary
- remove outdated sports listings from "主な競技" section leaving only rulebook link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b618b5e8e88326b36619456c2cb503