### PR TITLE
Link navigation to main sports section

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,8 +148,8 @@
       <p id="schedule-note" class="note">* 進行状況により変更となる場合があります。</p>
     </section>
 
-    <section id="sports" class="card">
-      <h2>主な競技</h2>
+    <section class="card">
+      <h2 id="sports">主な競技</h2>
         <div class="center" style="margin-top:16px">
           <a href="src/rulebook.pdf" class="btn secondary" target="_blank" rel="noopener">競技ルールブック（PDF）</a>
         </div>


### PR DESCRIPTION
## Summary
- ensure "競技" navigation item anchors to the "主な競技" heading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b62955f58c832689b663b190d42b45