### PR TITLE
Remove rain contingency FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,10 +160,6 @@
       <section id="faq" class="card">
       <h2>よくある質問</h2>
       <details>
-        <summary>雨の場合は？</summary>
-        <p>体育館で実施します。内履き（体育館シューズ）をご用意ください。</p>
-      </details>
-      <details>
         <summary>持ち物は？</summary>
         <p>タオル・帽子・運動のできる服装（スパイクは禁止）。</p>
       </details>


### PR DESCRIPTION
## Summary
- remove FAQ item about rainy day contingency to simplify event information

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b66fb5a4888326aa84fe105a4b1c34