### PR TITLE
Remove items-to-bring section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>座光寺地域市民運動会 2025｜告知ページ</title>
-  <meta name="description" content="座光寺地域市民運動会の告知ページ。日程、場所、競技、持ち物などを掲載。" />
+  <meta name="description" content="座光寺地域市民運動会の告知ページ。日程、場所、競技などを掲載。" />
   <meta property="og:title" content="座光寺地域市民運動会 2025｜告知ページ" />
   <meta property="og:description" content="日程・場所・競技はこちら。" />
   <meta property="og:type" content="website" />
@@ -114,7 +114,6 @@
           <div class="list">
             <div class="row"><div class="k">日付</div><div class="v">2025年10月12日(日) 午前8時30分〜12時00分頃　※雨天中止</div></div>
             <div class="row"><div class="k">場所</div><div class="v">座光寺小学校 グラウンド（雨天: 体育館）</div></div>
-            <div class="row"><div class="k">持ち物</div><div class="v">タオル、帽子、運動のできる服装（スパイクは禁止）</div></div>
           </div>
         </div>
         <aside class="card" aria-label="お知らせ">
@@ -156,14 +155,6 @@
       </section>
 
 
-
-      <section id="faq" class="card">
-      <h2>よくある質問</h2>
-      <details>
-        <summary>持ち物は？</summary>
-        <p>タオル・帽子・運動のできる服装（スパイクは禁止）。</p>
-      </details>
-    </section>
 
   </main>
 


### PR DESCRIPTION
## Summary
- remove "持ち物" details and FAQ entry from event page
- update meta description accordingly

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d2e7f0408326abac575b31e7e89f