### PR TITLE
Configure Codex media uploads to use src/img directory

### DIFF
--- a/codex.config.json
+++ b/codex.config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.codexcms.dev/schema.json",
+  "media": {
+    "defaultTarget": "images",
+    "targets": {
+      "images": {
+        "directory": "src/img",
+        "naming": {
+          "strategy": "datetime",
+          "sources": [
+            "metadata.exif.DateTimeOriginal",
+            "metadata.createdAt",
+            "system.createdAt"
+          ],
+          "format": "yyyyMMddHHmmss"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Codex configuration so uploaded images land in src/img
- enforce timestamp-based filenames using capture metadata
- create src/img placeholder to keep the directory tracked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb75fdfb388326b0fe053534483306