### PR TITLE
Add brochure download link to sports section

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,10 @@
     <section class="card">
       <h2 id="sports">主な競技</h2>
         <div class="center" style="margin-top:16px">
-          <a href="src/rulebook.pdf" class="btn secondary" target="_blank" rel="noopener">競技ルールブック（PDF）</a>
+          <div class="flex" style="justify-content:center">
+            <a href="src/rulebook.pdf" class="btn secondary" target="_blank" rel="noopener">競技ルールブック（PDF）</a>
+            <a href="src/brochure.pdf" class="btn" target="_blank" rel="noopener">運動会パンフレット（PDF）</a>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add a button linking to the event brochure PDF alongside the rulebook download
- center the pair of buttons while keeping existing styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89cf382d08326becbc4385c50b76c